### PR TITLE
Fix unchecked low level call typo

### DIFF
--- a/dataset/unchecked_low_level_calls/FibonacciBalance.sol
+++ b/dataset/unchecked_low_level_calls/FibonacciBalance.sol
@@ -38,3 +38,25 @@ contract FibonacciBalance {
         require(fibonacciLibrary.delegatecall(msg.data));
     }
 }
+
+// library contract - calculates fibonacci-like numbers;
+contract FibonacciLib {
+    // initializing the standard fibonacci sequence;
+    uint public start;
+    uint public calculatedFibNumber;
+
+    // modify the zeroth number in the sequence
+    function setStart(uint _start) public {
+        start = _start;
+    }
+
+    function setFibonacci(uint n) public {
+        calculatedFibNumber = fibonacci(n);
+    }
+
+    function fibonacci(uint n) internal returns (uint) {
+        if (n == 0) return start;
+        else if (n == 1) return start + 1;
+        else return fibonacci(n - 1) + fibonacci(n - 2);
+    }
+}

--- a/dataset/unchecked_low_level_calls/unchecked_return_value.sol
+++ b/dataset/unchecked_low_level_calls/unchecked_return_value.sol
@@ -1,7 +1,7 @@
 /*
  * @source: https://smartcontractsecurity.github.io/SWC-registry/docs/SWC-104#unchecked-return-valuesol
  * @author: -
- * @vulnerable_at_lines: 13,18
+ * @vulnerable_at_lines: 17
  */
 
 pragma solidity 0.4.25;
@@ -9,7 +9,6 @@ pragma solidity 0.4.25;
 contract ReturnValue {
 
   function callchecked(address callee) public {
-     // <yes> <report> UNCHECKED_LL_CALLS
     require(callee.call());
   }
 


### PR DESCRIPTION
Fix typo in `unchecked_low_level_calls/unchecked_return_value.sol` and add context to `unchecked_low_level_calls/FibonacciBalance.sol` (called contract)