### PR TITLE
Fix oyente output parser and typo in one reentrancy contract

### DIFF
--- a/dataset/reentrancy/reentrancy_cross_function.sol
+++ b/dataset/reentrancy/reentrancy_cross_function.sol
@@ -14,7 +14,7 @@ contract Reentrancy_cross_function {
     function transfer(address to, uint amount) {
         if (userBalances[msg.sender] >= amount) {
             userBalances[to] += amount;
-            userBalances[msg.sender] -= amount;
+        u   serBalances[msg.sender] -= amount;
         }
     }
 

--- a/dataset/reentrancy/reentrancy_cross_function.sol
+++ b/dataset/reentrancy/reentrancy_cross_function.sol
@@ -14,7 +14,7 @@ contract Reentrancy_cross_function {
     function transfer(address to, uint amount) {
         if (userBalances[msg.sender] >= amount) {
             userBalances[to] += amount;
-        u   serBalances[msg.sender] -= amount;
+            userBalances[msg.sender] -= amount;
         }
     }
 

--- a/src/output_parser/Oyente.py
+++ b/src/output_parser/Oyente.py
@@ -32,7 +32,9 @@ class Oyente(Parser):
             elif "INFO:symExec:	  " in line:
                 (key, value) = self.extract_result_line(line)
                 current_contract[key] = value
-            elif current_contract is not None and "INFO:symExec:" + current_contract['file'] in line:
+            elif current_contract is not None and current_contract['file'] in line:
+                if "INFO:symExec:" not in line:
+                    line = "INFO:symExec:" + line
                 (line, column, level, message) = line.replace("INFO:symExec:%s:" % (current_contract['file']), '').split(':')
                 current_contract['errors'].append({
                     'line': int(line),

--- a/src/output_parser/Oyente.py
+++ b/src/output_parser/Oyente.py
@@ -32,7 +32,7 @@ class Oyente(Parser):
             elif "INFO:symExec:	  " in line:
                 (key, value) = self.extract_result_line(line)
                 current_contract[key] = value
-            elif current_contract is not None and current_contract['file'] in line:
+            elif current_contract and current_contract['file'] in line:
                 if "INFO:symExec:" not in line:
                     line = "INFO:symExec:" + line
                 (line, column, level, message) = line.replace("INFO:symExec:%s:" % (current_contract['file']), '').split(':')


### PR DESCRIPTION
The oyente output parser fails to parse this output. When exists more than one vulnerability, the output parser just parses the first line, missing the others.
```
INFO:symExec:	====== Analysis Completed ======
INFO:root:contract /dataset/reentrancy/0x01f8c4e3fa3edeb29e514cba738d87ce8c091d3f.sol:PERSONAL_BANK:
INFO:symExec:	============ Results ===========
INFO:symExec:	  EVM Code Coverage: 			 98.0%
INFO:symExec:	  Integer Underflow: 			 False
INFO:symExec:	  Integer Overflow: 			 False
INFO:symExec:	  Parity Multisig Bug 2: 		 False
INFO:symExec:	  Callstack Depth Attack Vulnerability:  False
INFO:symExec:	  Transaction-Ordering Dependence (TOD): False
INFO:symExec:	  Timestamp Dependency: 		 False
INFO:symExec:	  Re-Entrancy Vulnerability: 		 True
INFO:symExec:/dataset/reentrancy/0x01f8c4e3fa3edeb29e514cba738d87ce8c091d3f.sol:57:17: Warning: Re-Entrancy Vulnerability.
                Log.AddMessage(msg.sender,_am,"Collect")
/dataset/reentrancy/0x01f8c4e3fa3edeb29e514cba738d87ce8c091d3f.sol:54:16: Warning: Re-Entrancy Vulnerability.
            if(msg.sender.call.value(_am)()
INFO:symExec:	====== Analysis Completed ======
```
The parser should take this line into account too.
```
/dataset/reentrancy/0x01f8c4e3fa3edeb29e514cba738d87ce8c091d3f.sol:54:16: Warning: Re-Entrancy Vulnerability.
            if(msg.sender.call.value(_am)()
```