### PR TITLE
Add support for remote datasets (as git repositories)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ __pycache__
 
 #Ignore vscode
 .vscode/
+
+#Ignore default remote datasets
+dataset/solidiFI

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ When running a tool the user must be aware of the solc compatibility. Due to the
 
 ## Smart Contracts Datasets
 
-We make available two smart contract datasets with SmartBugs:
+We make available three smart contract datasets with SmartBugs:
 
-- **SB Curated**: a curated dataset with 143 annotated contracts that can be used to evaluate the accuracy of analysis tools    .
+- **SB Curated**: a curated dataset that contains 143 annotated contracts with 208
+  tagged vulnerabilities that can be used to evaluate the accuracy of analysis tools.
 - **SB Wild**: a dataset with 47,518 unique contract from the Ethereum network (for details on 3 how they were collected, see [the ICSE 2020 paper](https://arxiv.org/abs/1910.10601))
-
-We also support **remote datasets** (as git repositories). Smartbugs is distributed with Ghaleb and Pattabiraman's [SolidiFI Benchmark](https://github.com/smartbugs/SolidiFI-benchmark), a dataset of buggy contracts injected with 9369 bugs of 7 different types.
+- **[SolidiFI Benchmark](https://github.com/smartbugs/SolidiFI-benchmark)**: a _remote dataset_ of contracts injected with 9369 bugs of 7 different types.
 
 ### SB Curated
 
@@ -110,6 +110,7 @@ We also support **remote datasets** (as git repositories). Smartbugs is distribu
 ### SB Wild
 
 SB Wild is available in a separated repository due to its size: [https://github.com/smartbugs/smartbugs-wild](https://github.com/smartbugs/smartbugs-wild)
+
 
 ### Remote Datasets
 You can set any git repository as a _remote dataset_. Smartbugs is distributed with Ghaleb and Pattabiraman's [SolidiFI Benchmark](https://github.com/smartbugs/SolidiFI-benchmark), a dataset of buggy contracts injected with 9369 bugs of 7 different types: reentrancy, timestamp dependency, unhandled exceptions, unchecked send, TOD, integer overflow/underflow, and use of tx.origin. 

--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ By default, results will be placed in the directory `results`.
 
 When running a tool the user must be aware of the solc compatibility. Due to the major changes introduced in solidity v0.5.0, we provide the option to pass another docker image to run contracts with solidity version below v0.5.0. However, please note that there may still be problems with the solidity compiler when compiling older versions of solidity code. 
 
-## Smart Contracts dataset
+## Smart Contracts Datasets
 
 We make available two smart contract datasets with SmartBugs:
 
 - **SB Curated**: a curated dataset with 143 annotated contracts that can be used to evaluate the accuracy of analysis tools    .
 - **SB Wild**: a dataset with 47,518 unique contract from the Ethereum network (for details on 3 how they were collected, see [the ICSE 2020 paper](https://arxiv.org/abs/1910.10601))
 
+We also support **remote datasets** (as git repositories). Smartbugs is distributed with Ghaleb and Pattabiraman's [SolidiFI Benchmark](https://github.com/smartbugs/SolidiFI-benchmark), a dataset of buggy contracts injected with 9369 bugs of 7 different types: reentrancy, timestamp dependency, unhandled exceptions, unchecked send, TOD, integer overflow/underflow, and use of tx.origin. To add new remote datasets, update the configuration file [dataset.yaml](config/dataset/dataset.yaml).
 
 ### SB Curated
 
@@ -112,7 +113,8 @@ SB Wild is available in a separated repository due to its size: [https://github.
 
 
 ## Work that uses SmartBugs
-- [SmartBugs was used to analyze 47,587 smart contracts](https://arxiv.org/abs/1910.10601). These contracts are available in a [separate repository](https://github.com/smartbugs/smartbugs-wild). The results are also in [their own repository](https://github.com/smartbugs/smartbugs-results).
+- [SmartBugs was used to analyze 47,587 smart contracts](https://joaoff.com/publication/2020/icse) (work published at ICSE 2020). These contracts are available in a [separate repository](https://github.com/smartbugs/smartbugs-wild). The results are also in [their own repository](https://github.com/smartbugs/smartbugs-results).
+- [SmartBugs was used to evaluate a simple extension of Smartcheck](https://joaoff.com/publication/2020/ase) (work published at ASE 2020, _Tool Demo Track_)
 - ... you are more than welcome to add your own work here!
 
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ We make available two smart contract datasets with SmartBugs:
 - **SB Curated**: a curated dataset with 143 annotated contracts that can be used to evaluate the accuracy of analysis tools    .
 - **SB Wild**: a dataset with 47,518 unique contract from the Ethereum network (for details on 3 how they were collected, see [the ICSE 2020 paper](https://arxiv.org/abs/1910.10601))
 
-We also support **remote datasets** (as git repositories). Smartbugs is distributed with Ghaleb and Pattabiraman's [SolidiFI Benchmark](https://github.com/smartbugs/SolidiFI-benchmark), a dataset of buggy contracts injected with 9369 bugs of 7 different types: reentrancy, timestamp dependency, unhandled exceptions, unchecked send, TOD, integer overflow/underflow, and use of tx.origin. To add new remote datasets, update the configuration file [dataset.yaml](config/dataset/dataset.yaml).
+We also support **remote datasets** (as git repositories). Smartbugs is distributed with Ghaleb and Pattabiraman's [SolidiFI Benchmark](https://github.com/smartbugs/SolidiFI-benchmark), a dataset of buggy contracts injected with 9369 bugs of 7 different types.
 
 ### SB Curated
 
@@ -111,6 +111,37 @@ We also support **remote datasets** (as git repositories). Smartbugs is distribu
 
 SB Wild is available in a separated repository due to its size: [https://github.com/smartbugs/smartbugs-wild](https://github.com/smartbugs/smartbugs-wild)
 
+### Remote Datasets
+You can set any git repository as a _remote dataset_. Smartbugs is distributed with Ghaleb and Pattabiraman's [SolidiFI Benchmark](https://github.com/smartbugs/SolidiFI-benchmark), a dataset of buggy contracts injected with 9369 bugs of 7 different types: reentrancy, timestamp dependency, unhandled exceptions, unchecked send, TOD, integer overflow/underflow, and use of tx.origin. 
+
+To add new remote datasets, update the configuration file [dataset.yaml](config/dataset/dataset.yaml) with
+the location of the dataset (`url`), the local directory where the dataset will be located (`local_dir`),
+and any relevant `subsets` (if any). As an example, here's the configuration for SolidiFI:
+
+```
+solidiFI: 
+    - url: git@github.com:smartbugs/SolidiFI-benchmark.git
+    - local_dir: dataset/solidiFI
+    - subsets: # Accessed as solidiFI/name 
+        - overflow_underflow: buggy_contracts/Overflow-Underflow
+        - reentrancy: buggy_contracts/Re-entrancy
+        - tod: buggy_contracts/TOD
+        - timestamp_dependency: buggy_contracts/Timestamp-Dependency
+        - unchecked_send: buggy_contracts/Unchecked-Send
+        - unhandled_exceptions: buggy_contracts/Unhandled-Exceptions
+        - tx_origin: buggy_contracts/tx.origin
+```
+
+With this configuration, if we want to run slither in the remote sub-directory `buggy_contracts/tx.origin`,
+we can run:
+
+```bash
+python3 smartBugs.py --tool slither --dataset solidiFI/tx_origin
+```
+
+To run it in the entire dataset, use `solidiFI` instead of `solidiFI/tx_origin`.
+
+When we use a remote dataset for the first time, we are asked to confirm the creation of the local copy.
 
 ## Work that uses SmartBugs
 - [SmartBugs was used to analyze 47,587 smart contracts](https://joaoff.com/publication/2020/icse) (work published at ICSE 2020). These contracts are available in a [separate repository](https://github.com/smartbugs/smartbugs-wild). The results are also in [their own repository](https://github.com/smartbugs/smartbugs-results).

--- a/config/dataset/dataset.yaml
+++ b/config/dataset/dataset.yaml
@@ -1,3 +1,4 @@
+# SB Curated (local)
 access_control: dataset/access_control
 arithmetic: dataset/arithmetic
 bad_randomness: dataset/bad_randomness
@@ -7,3 +8,16 @@ reentrancy: dataset/reentrancy
 short_addresses: dataset/short_addresses
 time_manipulation: dataset/time_manipulation
 unchecked_ll_calls: dataset/unchecked_low_level_calls
+
+# External datasets
+solidiFI: 
+    - url: git@github.com:smartbugs/SolidiFI-benchmark.git
+    - local_dir: dataset/solidiFI
+    - subsets: # Accessed as solidiFI/name 
+        - overflow_underflow: buggy_contracts/Overflow-Underflow
+        - reentrancy: buggy_contracts/Re-entrancy
+        - tod: buggy_contracts/TOD
+        - timestamp_dependency: buggy_contracts/Timestamp-Dependency
+        - unchecked_send: buggy_contracts/Unchecked-Send
+        - unhandled_exceptions: buggy_contracts/Unhandled-Exceptions
+        - tx_origin: buggy_contracts/tx.origin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML==5.1
 docker==3.7.0
 solidity_parser==0.0.3
+GitPython==3.1.5

--- a/smartBugs.py
+++ b/smartBugs.py
@@ -1,30 +1,33 @@
 #!/usr/bin/env python3
 
-import docker
+# import docker
 import yaml
-import logging
+# import logging
 import argparse
 import os
 import sys
 from datetime import timedelta
 from multiprocessing import Pool, Value
 from time import time, localtime, strftime
-from src.interface.cli import create_parser, DATASET_CHOICES, TOOLS_CHOICES
+from src.interface.cli import create_parser, getRemoteDataset, \
+                              isRemoteDataset, DATASET_CHOICES, TOOLS_CHOICES
 from src.docker_api.docker_api import analyse_files
+import git
 
 cfg_dataset_path = os.path.abspath('config/dataset/dataset.yaml')
-with open(cfg_dataset_path , 'r') as ymlfile:
+with open(cfg_dataset_path, 'r') as ymlfile:
     try:
         cfg_dataset = yaml.safe_load(ymlfile)
     except yaml.YAMLError as exc:
         print(exc)
 
-output_folder =  strftime("%Y%d%m_%H%M", localtime())
-logs = open('results/logs/SmartBugs_'+ output_folder +'.log', 'w')
+output_folder = strftime("%Y%d%m_%H%M", localtime())
+logs = open('results/logs/SmartBugs_' + output_folder + '.log', 'w')
 start_time = time()
 nb_task_done = Value('i', 0)
 total_execution = Value('f', 0)
 nb_task = 0
+
 
 def analyse(args):
     global logs, output_folder, nb_task, nb_task_done, total_execution
@@ -33,7 +36,7 @@ def analyse(args):
     try:
         start = time()
 
-        sys.stdout.write('\x1b[1;37m' + 'Analysing file [%d/%d]: ' %(nb_task_done.value, nb_task) + '\x1b[0m')
+        sys.stdout.write('\x1b[1;37m' + 'Analysing file [%d/%d]: ' % (nb_task_done.value, nb_task) + '\x1b[0m')
         sys.stdout.write('\x1b[1;34m' + file + '\x1b[0m')
         sys.stdout.write('\x1b[1;37m' + ' [' + tool + ']' + '\x1b[0m' + '\n')
 
@@ -46,15 +49,14 @@ def analyse(args):
             total_execution.value += time() - start
 
         duration = str(timedelta(seconds=round(time() - start)))
-        
+
         task_sec = nb_task_done.value/(time() - start_time)
         remaining_time = str(timedelta(seconds=round((nb_task - nb_task_done.value) / task_sec)))
 
-        
-        sys.stdout.write('\x1b[1;37m' + 'Done [%d/%d, %s]: ' %(nb_task_done.value, nb_task, remaining_time) + '\x1b[0m')
+        sys.stdout.write('\x1b[1;37m' + 'Done [%d/%d, %s]: ' % (nb_task_done.value, nb_task, remaining_time) + '\x1b[0m')
         sys.stdout.write('\x1b[1;34m' + file + '\x1b[0m')
-        sys.stdout.write('\x1b[1;37m' + ' [' + tool + '] in ' + duration +' ' + '\x1b[0m' + '\n')
-        logs.write('[%d/%d] ' %(nb_task_done.value, nb_task) + file + ' [' + tool + '] in ' + duration + ' \n')
+        sys.stdout.write('\x1b[1;37m' + ' [' + tool + '] in ' + duration + ' ' + '\x1b[0m' + '\n')
+        logs.write('[%d/%d] ' % (nb_task_done.value, nb_task) + file + ' [' + tool + '] in ' + duration + ' \n')
     except Exception as e:
         print(e)
         raise e
@@ -71,19 +73,50 @@ def exec_cmd(args: argparse.Namespace):
             DATASET_CHOICES.remove('all')
             args.dataset = DATASET_CHOICES
         for dataset in args.dataset:
-            dataset_path = cfg_dataset[dataset]
-            args.file.append(dataset_path)
+            # Directory search is recursive (see below), so
+            # if a remote D is used, we don't need to specify
+            # the subsets of D
+            base_name = dataset.split('/')[0]
+            if isRemoteDataset(cfg_dataset, base_name):
+                remote_info = getRemoteDataset(cfg_dataset, base_name)
+                base_path = remote_info['local_dir']
+
+                if not os.path.isdir(base_path):
+                    # local copy does not exist; we need to clone it
+                    print('\x1b[1;37m' + "%s is a remote dataset. Do you want to create a local copy? [Y/n] " % base_name + '\x1b[0m')
+                    answer = input()
+                    if answer in ['y', 'Y', 'Yes', 'YES', 'Ye', 'YE']:
+                        sys.stdout.write('\x1b[1;37m' + 'Cloning remote dataset [%s <- %s]... ' % (base_path, remote_info['url']) + '\x1b[0m')
+                        sys.stdout.flush()
+                        git.Repo.clone_from(remote_info['url'], base_path)
+                        sys.stdout.write('\x1b[1;37m\n' + 'Done.' + '\x1b[0m\n')
+                    else:
+                        print('\x1b[1;33m' + 'ABORTING: cannot proceed without local copy of remote dataset %s' % base_name + '\x1b[0m')
+                        quit()
+                else:
+                    sys.stdout.write('\x1b[1;37m' + 'Using remote dataset [%s <- %s] ' % (base_path, remote_info['url']) + '\x1b[0m\n')
+
+                if dataset == base_name:  # basename included
+                    dataset_path = base_path
+                    args.file.append(dataset_path)
+                if dataset != base_name and base_name not in args.dataset:
+                    sbset_name = dataset.split('/')[1]
+                    dataset_path = os.path.join(base_path, remote_info['subsets'][sbset_name])
+                    args.file.append(dataset_path)
+            else:
+                dataset_path = cfg_dataset[dataset]
+                args.file.append(dataset_path)
 
     for file in args.file:
-        #analyse files
+        # analyse files
         if os.path.basename(file).endswith('.sol'):
             files_to_analyze.append(file)
-        #analyse dirs recursively
+        # analyse dirs recursively
         elif os.path.isdir(file):
             for root, dirs, files in os.walk(file):
                 for name in files:
                     if name.endswith('.sol'):
-                        files_to_analyze.append(os.path.join(root,name))
+                        files_to_analyze.append(os.path.join(root, name))
         else:
             print('%s is not a directory or a solidity file' % file)
 
@@ -97,22 +130,20 @@ def exec_cmd(args: argparse.Namespace):
             results_folder = 'results/' + tool + '/' + output_folder
             if not os.path.exists(results_folder):
                 os.makedirs(results_folder)
-            
+
             if args.skip_existing:
                 file_name = os.path.splitext(os.path.basename(file))[0]
                 folder = os.path.join(results_folder, file_name, 'result.json')
                 if os.path.exists(folder):
                     continue
             tasks.append((tool, file))
-        
-    
+
     nb_task = len(tasks)
-    
+
     with Pool(processes=args.processes) as pool:
         pool.map(analyse, tasks)
 
     return logs
-
 
 
 if __name__ == '__main__':

--- a/smartBugs.py
+++ b/smartBugs.py
@@ -83,7 +83,7 @@ def exec_cmd(args: argparse.Namespace):
                     # local copy does not exist; we need to clone it
                     print('\x1b[1;37m' + "%s is a remote dataset. Do you want to create a local copy? [Y/n] " % base_name + '\x1b[0m')
                     answer = input()
-                    if answer in ['y', 'Y', 'yes', 'Yes', 'YES', '']:
+                    if answer.lower() in ['yes', 'y', '']:
                         sys.stdout.write('\x1b[1;37m' + 'Cloning remote dataset [%s <- %s]... ' % (base_path, remote_info['url']) + '\x1b[0m')
                         sys.stdout.flush()
                         git.Repo.clone_from(remote_info['url'], base_path)

--- a/smartBugs.py
+++ b/smartBugs.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
-# import docker
 import yaml
-# import logging
 import argparse
 import os
 import sys
@@ -85,7 +83,7 @@ def exec_cmd(args: argparse.Namespace):
                     # local copy does not exist; we need to clone it
                     print('\x1b[1;37m' + "%s is a remote dataset. Do you want to create a local copy? [Y/n] " % base_name + '\x1b[0m')
                     answer = input()
-                    if answer in ['y', 'Y', 'Yes', 'YES', 'Ye', 'YE']:
+                    if answer in ['y', 'Y', 'yes', 'Yes', 'YES', '']:
                         sys.stdout.write('\x1b[1;37m' + 'Cloning remote dataset [%s <- %s]... ' % (base_path, remote_info['url']) + '\x1b[0m')
                         sys.stdout.flush()
                         git.Repo.clone_from(remote_info['url'], base_path)

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -62,8 +62,7 @@ def isRemoteDataset(cfg_dataset, name):
                 merged = merge_two_dicts(merged, d)
 
         # A remote dataset needs to define an url and a local dir
-        if 'url' in merged and 'local_dir' in merged:
-            return True
+        return 'url' in merged and 'local_dir' in merged
     return False
 
 

--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -1,15 +1,15 @@
-
 #!/usr/bin/env python3
 import yaml
-import logging
+# import logging
 import argparse
 import os
 import sys
+from functools import reduce
 
 DATASET_CHOICES = ['all']
 TOOLS_CHOICES = ['all']
 CONFIG_TOOLS_PATH = os.path.abspath('config/tools')
-CONFIG_DATASET_PATH= os.path.abspath('config/dataset/dataset.yaml')
+CONFIG_DATASET_PATH = os.path.abspath('config/dataset/dataset.yaml')
 
 with open(CONFIG_DATASET_PATH, 'r') as ymlfile:
     try:
@@ -22,16 +22,17 @@ class InfoAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         for tool in values:
             cfg_path = os.path.abspath('config/tools/' + tool + '.yaml')
-            with open(cfg_path , 'r') as ymlfile:
+            with open(cfg_path, 'r') as ymlfile:
                 try:
                     cfg = yaml.safe_load(ymlfile)
                 except yaml.YAMLError as exc:
                     print(exc)
             if 'info' in cfg:
-                print('\x1b[1;37m' +  tool  + '\x1b[0m' + ': ' + cfg['info'])
+                print('\x1b[1;37m' + tool + '\x1b[0m' + ': ' + cfg['info'])
             else:
-                print('\x1b[1;37m' +  tool + '\x1b[0m' + ': ' +'no info provided.')
+                print('\x1b[1;37m' + tool + '\x1b[0m' + ': ' + 'no info provided.')
         parser.exit()
+
 
 class ListAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -48,24 +49,57 @@ class ListAction(argparse.Action):
                 sys.stdout.write('\n')
         parser.exit()
 
-#Parser stuff
+
+# Parser stuff
+def isRemoteDataset(cfg_dataset, name):
+    remote_info = cfg_dataset[name]
+    if isinstance(remote_info, list):
+        for prop in (e['url'] for e in remote_info if isinstance(e, dict) and 'url' in e):
+            return True
+    return False
+
+
+# transform remote dataset info in dictionary
+def getRemoteDataset(cfg_dataset, name):
+    remote_dataset = {}
+    remote_info = cfg_dataset[name]
+
+    if isRemoteDataset(cfg_dataset, name):
+        # url and local_dir
+        for prop_name in ["url", "local_dir", "subsets"]:
+            for prop_value in (e[prop_name] for e in remote_info if isinstance(e, dict) and prop_name in e):
+                remote_dataset[prop_name] = prop_value
+
+    # at this point, subsets is a list of dicts
+    # we want it to be a dictionary
+    remote_dataset['subsets'] = \
+        reduce(lambda a, b: dict(a, **b), remote_dataset['subsets'])
+
+    return remote_dataset
+
+
 def create_parser():
     parser = argparse.ArgumentParser(description="Static analysis of Ethereum smart contracts")
     group_source_files = parser.add_mutually_exclusive_group(required='True')
     group_tools = parser.add_mutually_exclusive_group(required='True')
     parser._optionals.title = "options:"
 
-
     parser.register('action', 'info', InfoAction)
     info = parser.add_argument_group('info')
 
-    parser.register('action', 'list', ListAction)
-    list = parser.add_argument_group('list')
+    parser.register('action', 'list_option', ListAction)
+    list_option = parser.add_argument_group('list_option')
 
     for name in cfg_dataset.items():
         DATASET_CHOICES.append(name[0])
 
-    #get tools available by parsing the name of the config files
+        # list all subsets of remote datasets
+        if isRemoteDataset(cfg_dataset, name[0]):
+            remote_dataset = getRemoteDataset(cfg_dataset, name[0])
+            for sbset_name in remote_dataset['subsets']:
+                DATASET_CHOICES.append(name[0] + '/' + sbset_name)
+
+    # get tools available by parsing the name of the config files
     tools = [os.path.splitext(f)[0] for f in os.listdir(CONFIG_TOOLS_PATH) if os.path.isfile(os.path.join(CONFIG_TOOLS_PATH, f))]
     for tool in tools:
         TOOLS_CHOICES.append(tool)
@@ -86,13 +120,12 @@ def create_parser():
                         choices=TOOLS_CHOICES,
                         nargs='+',
                         help='select tool(s)')
-                        #required=True)
 
-    list.add_argument('-l',
+    list_option.add_argument('-l',
                         '--list',
                         choices=['tools', 'datasets'],
                         nargs='+',
-                        action='list',
+                        action='list_option',
                         help='list tools or datasets')
 
     info.add_argument('-i',
@@ -101,7 +134,7 @@ def create_parser():
                         nargs='+',
                         action='info',
                         help='information about tool')
-    
+
     info.add_argument('--skip-existing',
                         action='store_true',
                         help='skip the analsis that already have results')


### PR DESCRIPTION
This PR adds support for remote datasets (as git repositories) and configures Smartbugs with a new remote dataset: solidiFI.

SolidiFI is a dataset of buggy contracts injected with 9369 bugs of 7 different types: reentrancy, timestamp dependency, unhandled exceptions, unchecked send, TOD, integer overflow/underflow, and use of tx.origin. 