### PR TITLE
Fix: treat solidity version consistently as a single number

### DIFF
--- a/src/execution/docker_api.py
+++ b/src/execution/docker_api.py
@@ -108,7 +108,7 @@ def analyse_files(task: 'Execution_Task'):
         # bind directory path instead of file path to allow imports in the same directory
         volume_bindings = mount_volumes(working_dir)
 
-        image = tool_image(cfg, get_solc_version(file) if not task.execution_configuration.is_bytecode else 5, is_bytecode=task.execution_configuration.is_bytecode)
+        image = tool_image(cfg, get_solc_version(file), is_bytecode=task.execution_configuration.is_bytecode)
 
         cmd = cfg[cmd_key]
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -25,8 +25,9 @@ def get_solc_version(file: str):
         with open(file, 'r', encoding='utf-8') as fd:
             sourceUnit = parser.parse(fd.read())
         solc_version = sourceUnit['children'][0]['value'].strip('^').split('.')
-        return (int(solc_version[1]), int(solc_version[2]))
+        if int(solc_version[0]) == 0:
+            return int(solc_version[1])
     except:
         msg = 'WARNING: could not parse solidity file to get solc version'
         logs.print(f"{COLWARN}{msg}{COLRESET}", msg)
-    return (None, None)
+    return None


### PR DESCRIPTION
For a Solidity version _a.b.c_, `get_solc_version` used to return the tuple _(b,c)_, but the caller expected the single number _b_.  Because of this mismatch, the default version of the docker images was used for all contracts, leading to many failing compilations.

The fix modifies `get_solc_version` to return only _b_. Moreover, it removes an unnecessary case distinction in the argument of a `tool_image` call, as the decision to use the default image in case of bytecode is done in `tool_image` anyway.