### PR TITLE
Fix bug in get_solidity_version: return number instead of tuple

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -25,8 +25,9 @@ def get_solc_version(file: str):
         with open(file, 'r', encoding='utf-8') as fd:
             sourceUnit = parser.parse(fd.read())
         solc_version = sourceUnit['children'][0]['value'].strip('^').split('.')
-        return (int(solc_version[1]), int(solc_version[2]))
+        if solc_version[0] == '0':
+            return int(solc_version[1])
     except:
         msg = 'WARNING: could not parse solidity file to get solc version'
         logs.print(f"{COLWARN}{msg}{COLRESET}", msg)
-    return (None, None)
+    return None


### PR DESCRIPTION
`get_solc_version` currently returns a tuple of numbers, but the calling context expects a single integer. As a consequence, the default image (with the newer version of solc) is used, leading to compilation errors for 0.4.x source code.