### PR TITLE
fixing "run all tools"

### DIFF
--- a/src/interface/cli.py
+++ b/src/interface/cli.py
@@ -23,7 +23,8 @@ for name,location in cfg_dataset.items():
     else:
         DATASET_CHOICES.append(name)
 
-TOOLS_CHOICES = ['all'].extend(TOOLS.keys())
+TOOLS_CHOICES = ['all']
+TOOLS_CHOICES += TOOLS.keys()
 
 def is_remote_info(info):
     return isinstance(info,dict) and 'url' in info and 'local_dir' in info


### PR DESCRIPTION
TOOLS_CHOICES = ['all'].extend(TOOLS.keys()) was returning None, so it was impossible to run all tools. 
Fixed it by appending TOOLS.keys() on the next line
Tested on Python 3.8