### PR TITLE
Change exit code for --version from 1 to 0

### DIFF
--- a/sb/cli.py
+++ b/sb/cli.py
@@ -111,7 +111,7 @@ Python {sb.cfg.CPU.get('python_version')}
 {sb.cfg.UNAME.system} {sb.cfg.UNAME.release} {sb.cfg.UNAME.version}
 CPU {sb.cfg.CPU.get('brand_raw')}\
 """)
-        sys.exit(1)
+        sys.exit(0)
 
     cfg_file = args["configuration"]
 


### PR DESCRIPTION
0 and 1 are exit codes.

exit(0) means a clean exit without any errors / problems

exit(1) means there was some issue / error / problem and that is why the program is exiting.