### PR TITLE
Fix timeout in ConFuzzius when analyzing Solidity file with more than one contract

### DIFF
--- a/tools/confuzzius/scripts/do_solidity
+++ b/tools/confuzzius/scripts/do_solidity
@@ -9,9 +9,15 @@ chmod +x "$BIN/solc"
 
 touch /root/results.json
 
-if [ "$TIMEOUT" -lt 20 ]; then
+count=0
+for _ in $(python3 "$BIN"/printContractNames.py "$FILENAME"); do
+  count=$((count + 1))
+done
+
+# Fuzz each contract at least 10 seconds
+to=$(((TIMEOUT - (10 * count)) / count))
+if [ "$TIMEOUT" -eq 0 ] || [ $to -lt 10 ]; then
   python3 fuzzer/main.py -s "$FILENAME" --evm byzantium --results results.json --seed 1427655
 else
-  TO=$((TIMEOUT - 10))
-  python3 fuzzer/main.py -s "$FILENAME" --evm byzantium --results results.json --seed 1427655 --timeout $TO
+  python3 fuzzer/main.py -s "$FILENAME" --evm byzantium --results results.json --seed 1427655 --timeout $to
 fi

--- a/tools/confuzzius/scripts/printContractNames.py
+++ b/tools/confuzzius/scripts/printContractNames.py
@@ -1,0 +1,33 @@
+import sys, json
+from subprocess import PIPE, Popen
+
+filename = sys.argv[1]
+cmd = ["solc", "--standard-json", "--allow-paths", ".,/"]
+settings = {
+    "optimizer": {"enabled": False},
+    "outputSelection": {
+        "*": {
+            "*": [ "evm.deployedBytecode" ],
+        }
+    },
+}
+
+input_json = json.dumps(
+    {
+        "language": "Solidity",
+        "sources": {filename: {"urls": [filename]}},
+        "settings": settings,
+    }
+)
+p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+stdout, stderr = p.communicate(bytes(input_json, "utf8"))
+out = stdout.decode("UTF-8")
+result = json.loads(out)
+for error in result.get("errors", []):
+    if error["severity"] == "error":
+        print(error["formattedMessage"])
+        sys.exit(1)
+contracts = result["contracts"][filename]
+for contract in contracts.keys():
+    if len(contracts[contract]["evm"]["deployedBytecode"]["object"]):
+        print(contract)


### PR DESCRIPTION
This PR resolves the timeout issue in ConFuzzius when analyzing a Solidity file with more than one smart contract. Now, at first the number of contracts in the respective file is determined, next, an appropriate timeout is calculated since the timeout option of the tool applies to every contract in the file.