### PR TITLE
Fix: Resolving #177 for handling arguments (that contain spaces) correctly

### DIFF
--- a/smartbugs
+++ b/smartbugs
@@ -10,4 +10,4 @@ done
 SB=$( cd -P "$( dirname "$SOURCE" )" >/dev/null 2>&1 && pwd )
 
 source "$SB/venv/bin/activate"
-PYTHONPATH="$SB:$PYTHONPATH" python -m sb $*
+PYTHONPATH="$SB:$PYTHONPATH" python -m sb "$@"


### PR DESCRIPTION
I tested with the following commands and now the arguments are passed correctly to the Python script from entry point bash script:

```Bash
 ./smartbugs/smartbugs -c "experiment_results/1-project_patches1_tmp0.9_topp0.3_gpt-4-0125-preview/Coinfabrik-Polymath Core Audit/polymath-core-dev-3.1.0/contracts/datastore/DataStore.sol/slither/vulnerability-2/candidate_patches/patch_0/smartbugs_config.yml" -f "experiment_results/1-project_patches1_tmp0.9_topp0.3_gpt-4-0125-preview/Coinfabrik-Polymath Core Audit/polymath-core-dev-3.1.0/contracts/datastore/DataStore.sol/slither/vulnerability-2/candidate_patches/patch_0/patch_0.sol"
```