### PR TITLE
Update four findings for Slither, and the corresponding SWC, DASP IDs.

### DIFF
--- a/tools/slither/findings.yaml
+++ b/tools/slither/findings.yaml
@@ -103,3 +103,7 @@ variable-scope: {}
 void-cst: {}
 weak-prng: {}
 write-after-write: {}
+cache-array-length: {}
+cyclomatic-complexity: {}
+immutable-states: {}
+return-bomb: SWC-128, DASP-5

--- a/tools/slither/parser.py
+++ b/tools/slither/parser.py
@@ -89,6 +89,10 @@ FINDINGS = {
     "void-cst",
     "weak-prng",
     "write-after-write",
+    "cache-array-length",
+    "cyclomatic-complexity",
+    "immutable-states",
+    "return-bomb"
 }
 
 LOCATION = re.compile("/sb/(.*?)#([0-9-]*)")


### PR DESCRIPTION
Hi, I find that the current Finding mappings lack these four vulnerability identifiers for Slither, which would result in the parsing failure. 
I have updated them into Slither's `findings.yaml` and mapped the corresponding SWC and DASP IDs according to Slither's doc.

Hope it helps.

```
cache-array-length: {}
cyclomatic-complexity: {}
immutable-states: {}
return-bomb: SWC-128, DASP-5
```